### PR TITLE
Allow users to define their own status getter and setter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,22 @@
 "use strict"
 
-var createMachine = function(reducersObject) {
+var defaultGetStatus = function (state) {
+    return state.status
+}
+
+var defaultSetStatus = function (state, status) {
+    return Object.assign({}, state, {'status': status})
+}
+
+var createMachine = function(reducersObject, getStatus=defaultGetStatus, setStatus=defaultSetStatus) {
     return function(state, action) {
-      var status = (state && state.status) ? state.status : 'INIT'
+      var status = (state && getStatus(state)) ? getStatus(state) : 'INIT'
       var reducer = reducersObject[status]
       if (!reducer) {
           throw new Error('reducersObject missing reducer for status ' + status)
       }
       const nextState = reducer(state, action)
-      return Object.assign({}, nextState, {'status': nextState.status || status})
+      return setStatus(nextState, getStatus(nextState) || status)
     }
 }
 

--- a/test.js
+++ b/test.js
@@ -38,61 +38,104 @@ const inProgressReducer = (state = {}, action) => {
     }
 }
 
-const fetchUsersReducer = createMachine({
-    'INIT': initReducer,
-    'IN_PROGRESS': inProgressReducer
-})
+
+const initReducerWithCustomStatus = (state = {}, action) => {
+    switch (action.type) {
+    case 'FETCH_USERS':
+        return Object.assign({}, state, {
+            error: null,
+            my_custom_status: 'IN_PROGRESS'
+    })
+    default:
+        return state
+    }
+}
+
+const inProgressReducerWithCustomStatus = (state = {}, action) => {
+
+    switch (action.type) {
+    case 'FETCH_USERS_RESPONSE':
+        return Object.assign({}, state, {
+            error: null,
+            users: action.payload.users,
+            my_custom_status: 'INIT'
+        })
+    case 'FETCH_USERS_FAIL':
+        return Object.assign({}, state, {
+            error: action.payload,
+            my_custom_status: 'INIT'
+        })
+    default:
+        return state
+    }
+}
+
 
 // END FIXTURES
 
 // BEGIN HELPERS
 
-let state = undefined
-let prevState = undefined
+const createDummyStore = function (reducer, initialState) {
+  let state = initialState
+  let prevState = state
 
-const action = (type, payload) => {
-    prevState = state
-    state = fetchUsersReducer(state, {type, payload})
+  return {
+    dispatch (type, payload) {
+      prevState = state
+      state = reducer(state, {type, payload})
+    },
+    expectState (expectedState, maybeMessage) {
+      assert.deepEqual(state, expectedState, maybeMessage)
+    },
+    expectStateUnchanged (maybeMessage) {
+      assert.deepEqual(state, prevState, maybeMessage)
+    }
+  }
 }
-
-const expect = (expected, maybeMessage) => assert.deepEqual(state, expected, maybeMessage)
 
 // END HELPERS
 
-// run the reducer and go through several status transitions
+// go through several status transitions
 // to test a typical scenario—making an API call
 
-action('DUMMY')
-expect({
+const fetchUsersReducer = createMachine({
+    'INIT': initReducer,
+    'IN_PROGRESS': inProgressReducer
+})
+
+const store = createDummyStore(fetchUsersReducer)
+
+store.dispatch('DUMMY')
+store.expectState({
     status: 'INIT',
 }, 'Should set initial status to "INIT"')
 
-action('FETCH_USERS_RESPONSE', {users})
-expect(prevState, 'Should ignore messages when not handled by current status')
+store.dispatch('FETCH_USERS_RESPONSE', {users})
+store.expectStateUnchanged('Should ignore messages when not handled by current status')
 
-action('FETCH_USERS')
-expect({
+store.dispatch('FETCH_USERS')
+store.expectState({
     error: null,
     status: 'IN_PROGRESS'
 })
 
-action('FETCH_USERS_FAIL', 'timeout')
-expect({
+store.dispatch('FETCH_USERS_FAIL', 'timeout')
+store.expectState({
     error: 'timeout',
     status: 'INIT'
 })
 
-action('FETCH_USERS')
-expect({
+store.dispatch('FETCH_USERS')
+store.expectState({
     error: null,
     status: 'IN_PROGRESS'
 })
 
-action('FETCH_USERS')
-expect(prevState)
+store.dispatch('FETCH_USERS')
+store.expectStateUnchanged()
 
-action('FETCH_USERS_RESPONSE', {users})
-expect({
+store.dispatch('FETCH_USERS_RESPONSE', {users})
+store.expectState({
     error: null,
     status: 'INIT',
     users
@@ -100,13 +143,60 @@ expect({
 
 assert.throws(
     () => {
-        let store = {status: 'STATUS_NOT_IN_CREATE_MACHINE'}
         const reducer = createMachine({})
-        store = reducer(store, {type: 'DUMMY'})
-
+        const store = createDummyStore(reducer, {status: 'STATUS_NOT_IN_CREATE_MACHINE'})
+        store.dispatch('DUMMY')
     },
     err => err.message === 'reducersObject missing reducer for status STATUS_NOT_IN_CREATE_MACHINE',
     'should error when status not found'
 )
+
+const reducerWithCustomStatusSupport = createMachine(
+  {
+    'INIT': initReducerWithCustomStatus,
+    'IN_PROGRESS': inProgressReducerWithCustomStatus
+  },
+  (state) => state.my_custom_status,
+  (state, newStatus) => Object.assign({}, state, {my_custom_status: newStatus})
+)
+
+const storeWithCustomStatus = createDummyStore(reducerWithCustomStatusSupport)
+
+storeWithCustomStatus.dispatch('DUMMY')
+storeWithCustomStatus.expectState({
+    my_custom_status: 'INIT',
+}, 'Should set initial status to "INIT"')
+
+storeWithCustomStatus.dispatch('FETCH_USERS_RESPONSE', {users})
+storeWithCustomStatus.expectStateUnchanged('Should ignore messages when not handled by current status')
+
+storeWithCustomStatus.dispatch('FETCH_USERS')
+storeWithCustomStatus.expectState({
+    error: null,
+    my_custom_status: 'IN_PROGRESS'
+})
+
+storeWithCustomStatus.dispatch('FETCH_USERS_FAIL', 'timeout')
+storeWithCustomStatus.expectState({
+    error: 'timeout',
+    my_custom_status: 'INIT'
+})
+
+storeWithCustomStatus.dispatch('FETCH_USERS')
+storeWithCustomStatus.expectState({
+    error: null,
+    my_custom_status: 'IN_PROGRESS'
+})
+
+storeWithCustomStatus.dispatch('FETCH_USERS')
+storeWithCustomStatus.expectStateUnchanged()
+
+storeWithCustomStatus.dispatch('FETCH_USERS_RESPONSE', {users})
+storeWithCustomStatus.expectState({
+    error: null,
+    my_custom_status: 'INIT',
+    users
+})
+
 
 console.log('success')


### PR DESCRIPTION
This will allow
1) to use other field instead of ‘status’
2) to use Immutable.js of similar libraries:

```javascript
const fetchUsersReducer = createMachine({
    'INIT': immutableInitReducer,
    'IN_PROGRESS': immutableInProgressReducer
}, (state) => state.get('my_status'), (state, status) => state.set('my_status', status))
```