### PR TITLE
When the action is unhandled, return same state

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ var createMachine = function(reducersObject) {
           throw new Error('reducersObject missing reducer for status ' + status)
       }
       const nextState = reducer(state, action)
+      if (nextState === state) {
+          return state
+      }
       return Object.assign({}, nextState, {'status': nextState.status || status})
     }
 }

--- a/test.js
+++ b/test.js
@@ -68,6 +68,10 @@ test('should transition between states', t => {
         status: 'INIT',
     }, 'Should set initial status to "INIT"')
 
+    action('DUMMY AGAIN')
+    
+    t.equals(state, prevState, 'Should not change the state when an action is unhandled')
+
     action('FETCH_USERS_RESPONSE', {users})
     expectState(prevState, 'Should ignore messages when not handled by current status')
 


### PR DESCRIPTION
When the action is unhandled, return same state
This supports testing and debugging for unhandled actions: users
should expect that the same state will be returned if the action
was unhandled.

Fix #9