### PR TITLE
ioc-example

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,22 @@
 "use strict"
 
-var createMachine = function(reducersObject) {
-    return function(state, action) {
-      var status = (state && state.status) ? state.status : 'INIT'
-      var reducer = reducersObject[status]
-      if (!reducer) {
-          throw new Error('reducersObject missing reducer for status ' + status)
-      }
-      const nextState = reducer(state, action)
-      if (nextState === state) {
-          return state
-      }
-      return Object.assign({}, nextState, {'status': nextState.status || status})
-    }
+function createMachine(lifecycleHooks) {
+  const defaultLifecycleHooks = {
+    getStatus:(state,initialStatus)=>(state && state.status) || initialStatus,
+    getReducer:(reducersObject,status)=>{},
+    getNextState:(state,nextState,status)=>state === nextState ? state : Object.assign({status}, nextState)
+  };
+  const {getNextState, getStatus, getReducer} = Object.assign(defaultLifecycleHooks, lifecycleHooks);
+  const INIT = 'INIT';
+  return function stateMachine(state, action){
+    const status = getStatus(state, INIT);
+    const reducer = getReducer(status);
+    if(!isFunction(reducer)){invalidReducerError(status);}
+    return getNextState(state, reducer(state, action), status);
+  }
 }
+
+function invalidTypeError(status){throw new Error(`Invalid reducer for ${status}. It must be a function.`);}
+function isFunction(arg){return typeof arg === 'function';}
 
 module.exports = {createMachine: createMachine, become: 'status' /* for backwards compatibility */}

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
 function createMachine(lifecycleHooks) {
   const defaultLifecycleHooks = {
     getStatus:(state,initialStatus)=>(state && state.status) || initialStatus,
-    getReducer:(reducersObject,status)=>{},
-    getNextState:(state,nextState,status)=>state === nextState ? state : Object.assign({status}, nextState)
+    getReducer:(status)=>{},
+    getNextState:(state, nextState,status)=>state === nextState ? state : Object.assign({status}, nextState)
   };
   const {getNextState, getStatus, getReducer} = Object.assign(defaultLifecycleHooks, lifecycleHooks);
   const INIT = 'INIT';
@@ -16,7 +16,7 @@ function createMachine(lifecycleHooks) {
   }
 }
 
-function invalidTypeError(status){throw new Error(`Invalid reducer for ${status}. It must be a function.`);}
+function invalidReducerError(status){throw new Error(`Invalid reducer for ${status}. It must be a function.`);}
 function isFunction(arg){return typeof arg === 'function';}
 
-module.exports = {createMachine: createMachine, become: 'status' /* for backwards compatibility */}
+module.exports = {createMachine, become: 'status' /* for backwards compatibility */}


### PR DESCRIPTION
Hey Max,

Like where you're going with this.  Just noticed that you're maintaining different branches for immutable.  Had a couple thoughts that might eliminate the need for it.  PR attached as an example (love that the code is short).

 * getReducer(status) -> fn reduces complexity and a eliminates the need to store an object reference
 * getStatus() & getNextState() enable immutable, array-like states, and non-=== equality comparisons.