### PR TITLE
pass all arguments to inner reducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ const fetchUsersReducer = (state, action) => {
 
 The (marginal) advantages of using redux-machine over just using the FSM pattern is that you can more clearly express intent and write slightly less code.
 
+## Supporting an Extra Argument
+redux-machine supports to passing an extra argument to state reducers, for cases where a state reducer requires a third argument for other state it dpeneds on. 
+
 ## Asynchronous Effects
 
 redux-machine doesn't prescribe a way of handling asynchronous effects such as API calls. This leaves it open for you to use [no async effects library](http://stackoverflow.com/a/34599594/2482570), [redux-loop](https://github.com/redux-loop/redux-loop), [redux-thunk](https://github.com/gaearon/redux-thunk), [redux-saga](https://github.com/yelouafi/redux-saga), [redux-funk](https://github.com/mheiber/redux-funk) or [anything else](https://github.com/markerikson/redux-ecosystem-links/blob/master/side-effects.md).

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var createMachine = function(reducersObject) {
       if (!reducer) {
           throw new Error('reducersObject missing reducer for status ' + status)
       }
-      const nextState = reducer(state, action)
+      const nextState = reducer.apply(undefined, arguments);
       if (nextState === state) {
           return state
       }

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 "use strict"
 
 var createMachine = function(reducersObject) {
-    return function(state, action) {
+    return function(state, action, extraArgument) {
       var status = (state && state.status) ? state.status : 'INIT'
       var reducer = reducersObject[status]
       if (!reducer) {
           throw new Error('reducersObject missing reducer for status ' + status)
       }
-      const nextState = reducer.apply(undefined, arguments);
+      const nextState = reducer(state, action, extraArgument)
       if (nextState === state) {
           return state
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-machine",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "a tiny lib for creating state machines as swappable Redux reducers",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -69,7 +69,6 @@ test('should transition between states', t => {
     }, 'Should set initial status to "INIT"')
 
     action('DUMMY AGAIN')
-    
     t.equals(state, prevState, 'Should not change the state when an action is unhandled')
 
     action('FETCH_USERS_RESPONSE', {users})
@@ -102,6 +101,62 @@ test('should transition between states', t => {
         status: 'INIT',
         users
     })
+
+    t.end()
+})
+
+test('should pass all arguments to inner reducers', t => {
+    const configReducer =  (state = {}, action) => state;
+    const gameReducer = (state = {}, action, isMuted) => {
+        switch (action.type) {
+        case 'START':
+            const audio = (isMuted === true) ? 'OFF' : 'ON'
+            return Object.assign({}, state, {
+                audio: audio
+        })
+        default:
+            return state
+        }
+    }
+    const innerReducer = (state = {}, action) => {
+        const isMuted = state.config ? state.config.isMuted : undefined
+        return {
+          'game': gameReducer(state.game, action, isMuted),
+          'config': configReducer(state.config, action)
+        }
+    }
+    const fsmReducer = createMachine({
+        'INIT': innerReducer
+    });
+    const store = createStore(fsmReducer, undefined)
+    store.dispatch({
+      type: 'START'
+    })
+    t.deepEquals(store.getState(), {
+        status: 'INIT',
+        game: {
+          audio: 'ON'
+        },
+        config: {}
+    }, 'Should turn game audio "ON" if isMuted !== true')
+
+    const silentStore = createStore(fsmReducer, {
+      config: {
+        isMuted: true
+      }
+    })
+    silentStore.dispatch({
+      type: 'START'
+    })
+    t.deepEquals(silentStore.getState(), {
+        status: 'INIT',
+        game: {
+          audio: 'OFF'
+        },
+        config: {
+          isMuted: true
+        }
+    }, 'Should turn game audio "OFF" if isMuted === true')
 
     t.end()
 })

--- a/test.js
+++ b/test.js
@@ -105,7 +105,7 @@ test('should transition between states', t => {
     t.end()
 })
 
-test('should pass all arguments to inner reducers', t => {
+test('should be able to pass an extraArgument to inner reducers', t => {
     const configReducer =  (state = {}, action) => state;
     const gameReducer = (state = {}, action, isMuted) => {
         switch (action.type) {


### PR DESCRIPTION
In some cases, I want to share states between two slice reducers. As per this document, it can be achieved by passing the state as a third argument to a reducer:
https://github.com/reactjs/redux/blob/master/docs/recipes/reducers/BeyondCombineReducers.md

redux-machine should allow all arguments to be passed through to a wrapped reducer.